### PR TITLE
finish naming provider

### DIFF
--- a/plugins/org.erlide.erlang.tests/.classpath
+++ b/plugins/org.erlide.erlang.tests/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry excluding="org/erlide/erlang/parserdb/|org/erlide/erlang/FilesTest.java" kind="src" path="src"/>
+	<classpathentry excluding="org/erlide/erlang/parserdb/" kind="src" path="src"/>
 	<classpathentry kind="src" path="src-gen"/>
 	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>

--- a/plugins/org.erlide.erlang.tests/erlang_tests.launch
+++ b/plugins/org.erlide.erlang.tests/erlang_tests.launch
@@ -15,6 +15,9 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[debug]" value="org.eclipse.jdt.junit.launchconfig"/>
+</mapAttribute>
 <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
 <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>

--- a/plugins/org.erlide.erlang.tests/src/org/erlide/erlang/FilesTest.java
+++ b/plugins/org.erlide.erlang.tests/src/org/erlide/erlang/FilesTest.java
@@ -5,41 +5,43 @@ import org.eclipselabs.xtext.utils.unittesting.XtextRunner2;
 import org.eclipselabs.xtext.utils.unittesting.XtextTest;
 import org.erlide.ErlangInjectorProvider;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+@Ignore
 @RunWith(XtextRunner2.class)
 @InjectWith(ErlangInjectorProvider.class)
 public class FilesTest extends XtextTest {
 
-    @Before
-    public void setup() {
-        ignoreFormattingDifferences();
-        // ignoreSerializationDifferences();
-    }
+	@Before
+	public void setup() {
+		ignoreFormattingDifferences();
+		// ignoreSerializationDifferences();
+	}
 
-    @Test
-    public void test1() {
-        testFile("test1.erl");
-    }
+	@Test
+	public void test1() {
+		testFile("test1.erl");
+	}
 
-    @Test
-    public void test2() {
-        testFile("test2.erl");
-    }
+	@Test
+	public void test2() {
+		testFile("test2.erl");
+	}
 
-    @Test
-    public void test3() {
-        testFile("test3.erl");
-    }
+	@Test
+	public void test3() {
+		testFile("test3.erl");
+	}
 
-    @Test
-    public void testDocs() {
-        // testFile("test_docs.erl");
-    }
+	@Test
+	public void testDocs() {
+		// testFile("test_docs.erl");
+	}
 
-    @Test
-    public void erlide_scan() {
-        testFileNoSerializer("reference/erlide_scan.erl");
-    }
+	@Test
+	public void erlide_scan() {
+		testFileNoSerializer("reference/erlide_scan.erl");
+	}
 }

--- a/plugins/org.erlide.erlang.tests/src/org/erlide/naming/ErlangNamingTest.xtend
+++ b/plugins/org.erlide.erlang.tests/src/org/erlide/naming/ErlangNamingTest.xtend
@@ -14,6 +14,8 @@ import org.junit.runner.RunWith
 
 import static org.hamcrest.MatcherAssert.*
 import static org.hamcrest.Matchers.*
+import org.erlide.erlang.Function
+import org.erlide.erlang.FunExpr
 
 @RunWith(typeof(XtextRunner))
 @InjectWith(typeof(ErlangInjectorProvider))
@@ -32,7 +34,26 @@ class ErlangNamingTest {
             -module(x).
         ''')
         val name = namer.getFullyQualifiedName(module)
-        assertThat(name.toString, is("x")) 
+        assertThat(nameCvtr.toString(name), is("x")) 
+	}
+
+	@Test
+	def void moduleNameQuoted() {
+        val module = parser.parse('''
+            -module('X').
+        ''')
+        val name = namer.getFullyQualifiedName(module)
+        assertThat(nameCvtr.toString(name), is("'X'")) 
+	}
+
+	@Test
+	def void headerName() {
+        val module = parser.parse('''
+            -define(X, x).
+        ''')
+        val name = namer.getFullyQualifiedName(module)
+        // the name is generated for this embedded resource
+        assertThat(nameCvtr.toString(name), is("__synthetic0.erl,hrl")) 
 	}
 
 	@Test
@@ -61,4 +82,89 @@ class ErlangNamingTest {
         val name2 = namer.getFullyQualifiedName(dfn.elseForms.head)
         assertThat(nameCvtr.toString(name2), is("x:#y_2")) 
 	}
+	
+	@Test
+	def void functionName() {
+        val module = parser.parse('''
+            -module(x).
+            f() -> ok.
+        ''')
+        val name = namer.getFullyQualifiedName(module.forms.tail.head)
+        assertThat(nameCvtr.toString(name), is("x:f/0")) 
+	}
+
+	@Test
+	def void functionName_1() {
+        val module = parser.parse('''
+            -module(x).
+            f(X) -> ok.
+            f() -> ok.
+        ''')
+        val name1 = namer.getFullyQualifiedName(module.forms.tail.head)
+        assertThat(nameCvtr.toString(name1), is("x:f/1")) 
+        val name2 = namer.getFullyQualifiedName(module.forms.tail.tail.head)
+        assertThat(nameCvtr.toString(name2), is("x:f/0")) 
+	}
+
+	@Test
+	def void functionClause() {
+        val module = parser.parse('''
+            -module(x).
+            f(a) -> ok;
+            f(b) -> ok.
+        ''')
+        val clauses = (module.forms.tail.head as Function).clauses
+        val name1 = namer.getFullyQualifiedName(clauses.head)
+        assertThat(nameCvtr.toString(name1), is("x:f/1:0")) 
+        val name2 = namer.getFullyQualifiedName(clauses.tail.head)
+        assertThat(nameCvtr.toString(name2), is("x:f/1:1")) 
+	}
+
+	@Test
+	def void functionInline() {
+        val module = parser.parse('''
+            -module(x).
+            f() -> fun() -> ok end.
+        ''')
+        val fun = (module.forms.tail.head as Function).clauses.head.body.head as FunExpr
+        val name1 = namer.getFullyQualifiedName(fun)
+        assertThat(nameCvtr.toString(name1), is("x:f/0:0:fun_0")) 
+	}
+
+	@Test
+	def void functionInline_2() {
+        val module = parser.parse('''
+            -module(x).
+            f() -> ok, fun() -> ok end.
+        ''')
+        val fun = (module.forms.get(1) as Function).clauses.head.body.get(1) as FunExpr
+        val name1 = namer.getFullyQualifiedName(fun)
+        assertThat(nameCvtr.toString(name1), is("x:f/0:0:fun_1")) 
+	}
+
+	@Test
+	def void functionClauseInline() {
+        val module = parser.parse('''
+            -module(x).
+            f() -> fun() -> ok end.
+        ''')
+        val fun = (module.forms.tail.head as Function).clauses.head.body.head as FunExpr
+        val name1 = namer.getFullyQualifiedName(fun.clauses.head)
+        assertThat(nameCvtr.toString(name1), is("x:f/0:0:fun_0:0")) 
+	}
+
+	@Test
+	def void macroName() {
+        val module = parser.parse('''
+            -module(x).
+            -define(X, x).
+        ''')
+        val obj = module.forms.tail.head
+        val name1 = namer.getFullyQualifiedName(obj)
+        assertThat(nameCvtr.toString(name1), is("x:?X")) 
+	}
+
+
+
+	
 }

--- a/plugins/org.erlide.erlang.tests/xtend-gen/org/erlide/naming/ErlangNamingTest.java
+++ b/plugins/org.erlide.erlang.tests/xtend-gen/org/erlide/naming/ErlangNamingTest.java
@@ -13,7 +13,11 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.erlide.ErlangInjectorProvider;
 import org.erlide.erlang.ConditionalFormBlock;
+import org.erlide.erlang.Expression;
 import org.erlide.erlang.Form;
+import org.erlide.erlang.FunExpr;
+import org.erlide.erlang.Function;
+import org.erlide.erlang.FunctionClause;
 import org.erlide.erlang.Module;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
@@ -42,8 +46,40 @@ public class ErlangNamingTest {
       _builder.newLine();
       final Module module = this.parser.parse(_builder);
       final QualifiedName name = this.namer.getFullyQualifiedName(module);
-      String _string = name.toString();
+      String _string = this.nameCvtr.toString(name);
       Matcher<? super String> _is = Matchers.<String>is("x");
+      MatcherAssert.<String>assertThat(_string, _is);
+    } catch (Exception _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void moduleNameQuoted() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("-module(\'X\').");
+      _builder.newLine();
+      final Module module = this.parser.parse(_builder);
+      final QualifiedName name = this.namer.getFullyQualifiedName(module);
+      String _string = this.nameCvtr.toString(name);
+      Matcher<? super String> _is = Matchers.<String>is("\'X\'");
+      MatcherAssert.<String>assertThat(_string, _is);
+    } catch (Exception _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void headerName() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("-define(X, x).");
+      _builder.newLine();
+      final Module module = this.parser.parse(_builder);
+      final QualifiedName name = this.namer.getFullyQualifiedName(module);
+      String _string = this.nameCvtr.toString(name);
+      Matcher<? super String> _is = Matchers.<String>is("__synthetic0.erl,hrl");
       MatcherAssert.<String>assertThat(_string, _is);
     } catch (Exception _e) {
       throw Exceptions.sneakyThrow(_e);
@@ -103,6 +139,189 @@ public class ErlangNamingTest {
       String _string_1 = this.nameCvtr.toString(name2);
       Matcher<? super String> _is_1 = Matchers.<String>is("x:#y_2");
       MatcherAssert.<String>assertThat(_string_1, _is_1);
+    } catch (Exception _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void functionName() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("-module(x).");
+      _builder.newLine();
+      _builder.append("f() -> ok.");
+      _builder.newLine();
+      final Module module = this.parser.parse(_builder);
+      EList<Form> _forms = module.getForms();
+      Iterable<Form> _tail = IterableExtensions.<Form>tail(_forms);
+      Form _head = IterableExtensions.<Form>head(_tail);
+      final QualifiedName name = this.namer.getFullyQualifiedName(_head);
+      String _string = this.nameCvtr.toString(name);
+      Matcher<? super String> _is = Matchers.<String>is("x:f/0");
+      MatcherAssert.<String>assertThat(_string, _is);
+    } catch (Exception _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void functionName_1() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("-module(x).");
+      _builder.newLine();
+      _builder.append("f(X) -> ok.");
+      _builder.newLine();
+      _builder.append("f() -> ok.");
+      _builder.newLine();
+      final Module module = this.parser.parse(_builder);
+      EList<Form> _forms = module.getForms();
+      Iterable<Form> _tail = IterableExtensions.<Form>tail(_forms);
+      Form _head = IterableExtensions.<Form>head(_tail);
+      final QualifiedName name1 = this.namer.getFullyQualifiedName(_head);
+      String _string = this.nameCvtr.toString(name1);
+      Matcher<? super String> _is = Matchers.<String>is("x:f/1");
+      MatcherAssert.<String>assertThat(_string, _is);
+      EList<Form> _forms_1 = module.getForms();
+      Iterable<Form> _tail_1 = IterableExtensions.<Form>tail(_forms_1);
+      Iterable<Form> _tail_2 = IterableExtensions.<Form>tail(_tail_1);
+      Form _head_1 = IterableExtensions.<Form>head(_tail_2);
+      final QualifiedName name2 = this.namer.getFullyQualifiedName(_head_1);
+      String _string_1 = this.nameCvtr.toString(name2);
+      Matcher<? super String> _is_1 = Matchers.<String>is("x:f/0");
+      MatcherAssert.<String>assertThat(_string_1, _is_1);
+    } catch (Exception _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void functionClause() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("-module(x).");
+      _builder.newLine();
+      _builder.append("f(a) -> ok;");
+      _builder.newLine();
+      _builder.append("f(b) -> ok.");
+      _builder.newLine();
+      final Module module = this.parser.parse(_builder);
+      EList<Form> _forms = module.getForms();
+      Iterable<Form> _tail = IterableExtensions.<Form>tail(_forms);
+      Form _head = IterableExtensions.<Form>head(_tail);
+      final EList<FunctionClause> clauses = ((Function) _head).getClauses();
+      FunctionClause _head_1 = IterableExtensions.<FunctionClause>head(clauses);
+      final QualifiedName name1 = this.namer.getFullyQualifiedName(_head_1);
+      String _string = this.nameCvtr.toString(name1);
+      Matcher<? super String> _is = Matchers.<String>is("x:f/1:0");
+      MatcherAssert.<String>assertThat(_string, _is);
+      Iterable<FunctionClause> _tail_1 = IterableExtensions.<FunctionClause>tail(clauses);
+      FunctionClause _head_2 = IterableExtensions.<FunctionClause>head(_tail_1);
+      final QualifiedName name2 = this.namer.getFullyQualifiedName(_head_2);
+      String _string_1 = this.nameCvtr.toString(name2);
+      Matcher<? super String> _is_1 = Matchers.<String>is("x:f/1:1");
+      MatcherAssert.<String>assertThat(_string_1, _is_1);
+    } catch (Exception _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void functionInline() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("-module(x).");
+      _builder.newLine();
+      _builder.append("f() -> fun() -> ok end.");
+      _builder.newLine();
+      final Module module = this.parser.parse(_builder);
+      EList<Form> _forms = module.getForms();
+      Iterable<Form> _tail = IterableExtensions.<Form>tail(_forms);
+      Form _head = IterableExtensions.<Form>head(_tail);
+      EList<FunctionClause> _clauses = ((Function) _head).getClauses();
+      FunctionClause _head_1 = IterableExtensions.<FunctionClause>head(_clauses);
+      EList<Expression> _body = _head_1.getBody();
+      Expression _head_2 = IterableExtensions.<Expression>head(_body);
+      final FunExpr fun = ((FunExpr) _head_2);
+      final QualifiedName name1 = this.namer.getFullyQualifiedName(fun);
+      String _string = this.nameCvtr.toString(name1);
+      Matcher<? super String> _is = Matchers.<String>is("x:f/0:0:fun_0");
+      MatcherAssert.<String>assertThat(_string, _is);
+    } catch (Exception _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void functionInline_2() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("-module(x).");
+      _builder.newLine();
+      _builder.append("f() -> ok, fun() -> ok end.");
+      _builder.newLine();
+      final Module module = this.parser.parse(_builder);
+      EList<Form> _forms = module.getForms();
+      Form _get = _forms.get(1);
+      EList<FunctionClause> _clauses = ((Function) _get).getClauses();
+      FunctionClause _head = IterableExtensions.<FunctionClause>head(_clauses);
+      EList<Expression> _body = _head.getBody();
+      Expression _get_1 = _body.get(1);
+      final FunExpr fun = ((FunExpr) _get_1);
+      final QualifiedName name1 = this.namer.getFullyQualifiedName(fun);
+      String _string = this.nameCvtr.toString(name1);
+      Matcher<? super String> _is = Matchers.<String>is("x:f/0:0:fun_1");
+      MatcherAssert.<String>assertThat(_string, _is);
+    } catch (Exception _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void functionClauseInline() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("-module(x).");
+      _builder.newLine();
+      _builder.append("f() -> fun() -> ok end.");
+      _builder.newLine();
+      final Module module = this.parser.parse(_builder);
+      EList<Form> _forms = module.getForms();
+      Iterable<Form> _tail = IterableExtensions.<Form>tail(_forms);
+      Form _head = IterableExtensions.<Form>head(_tail);
+      EList<FunctionClause> _clauses = ((Function) _head).getClauses();
+      FunctionClause _head_1 = IterableExtensions.<FunctionClause>head(_clauses);
+      EList<Expression> _body = _head_1.getBody();
+      Expression _head_2 = IterableExtensions.<Expression>head(_body);
+      final FunExpr fun = ((FunExpr) _head_2);
+      EList<FunctionClause> _clauses_1 = fun.getClauses();
+      FunctionClause _head_3 = IterableExtensions.<FunctionClause>head(_clauses_1);
+      final QualifiedName name1 = this.namer.getFullyQualifiedName(_head_3);
+      String _string = this.nameCvtr.toString(name1);
+      Matcher<? super String> _is = Matchers.<String>is("x:f/0:0:fun_0:0");
+      MatcherAssert.<String>assertThat(_string, _is);
+    } catch (Exception _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void macroName() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("-module(x).");
+      _builder.newLine();
+      _builder.append("-define(X, x).");
+      _builder.newLine();
+      final Module module = this.parser.parse(_builder);
+      EList<Form> _forms = module.getForms();
+      Iterable<Form> _tail = IterableExtensions.<Form>tail(_forms);
+      final Form obj = IterableExtensions.<Form>head(_tail);
+      final QualifiedName name1 = this.namer.getFullyQualifiedName(obj);
+      String _string = this.nameCvtr.toString(name1);
+      Matcher<? super String> _is = Matchers.<String>is("x:?X");
+      MatcherAssert.<String>assertThat(_string, _is);
     } catch (Exception _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/plugins/org.erlide.erlang/src/org/erlide/naming/ErlangQualifiedNameConverter.java
+++ b/plugins/org.erlide.erlang/src/org/erlide/naming/ErlangQualifiedNameConverter.java
@@ -1,7 +1,6 @@
 package org.erlide.naming;
 
 import org.eclipse.xtext.naming.IQualifiedNameConverter;
-import org.eclipse.xtext.naming.QualifiedName;
 
 import com.google.inject.Singleton;
 
@@ -14,15 +13,4 @@ public class ErlangQualifiedNameConverter extends
 		return ":";
 	}
 
-	@Override
-	public QualifiedName toQualifiedName(String qualifiedNameAsString) {
-		// TODO Auto-generated method stub
-		return super.toQualifiedName(qualifiedNameAsString);
-	}
-
-	@Override
-	public String toString(QualifiedName qualifiedName) {
-		// TODO Auto-generated method stub
-		return super.toString(qualifiedName);
-	}
 }


### PR DESCRIPTION
Names are given to
modules: module name or file name for headers
functions: name/arity
funs: fun_<index in  parent's children list> ; note this counts even other expressions in the body
function clauses (in both cases): index in parent's children list

The qualified name is concatenated with ':'
